### PR TITLE
Fix test_lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: if [[ -n "$(terraform fmt -write=false)" ]]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi
       - run:
           name: Install tflint
-          command: curl -L -o /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v0.14.0/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
+          command: curl -L -o /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v0.29.1/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
       - run:
           name: Check Terraform configurations with tflint
           command: find . -name ".terraform" -prune -o -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m; do (cd "$m" && tflint && echo "√ $m") || exit 1 ; done
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - run:
           name: Install tfsec
-          command: env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec
+          command: env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec
       - run:
           name: Terraform static code analysis with tfsec
           command: tfsec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - run:
           name: Install tfsec
-          command: env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec
+          command: env GO111MODULE=on go get -u github.com/aquasecurity/tfsec/cmd/tfsec
       - run:
           name: Terraform static code analysis with tfsec
           command: tfsec

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.dll
 *.so
 *.dylib
+handler/bin/*
 
 # Test binary, built with `go test -c`
 *.test

--- a/handler/Makefile
+++ b/handler/Makefile
@@ -37,8 +37,8 @@ test: lint
 	go test -v ./...
 
 lint: go.mod dependencies
-	golangci-lint run ./...
-	gosec ./...
+	./bin/golangci-lint run ./...
+	./bin/gosec ./...
 
 go.mod:
 ifeq (,$(wildcard go.mod))
@@ -48,10 +48,12 @@ endif
 dependencies: $(GOLANGCILINT) $(GOSEC) $(GHR)
 
 $(GOLANGCILINT):
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.23.6
+	# linter fails on latest version, pinning to last passing version. latest version is:
+		# curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.41.1
 
 $(GOSEC):
-	go get -u github.com/securego/gosec/cmd/gosec
+	curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.8.1
 
 $(GHR):
 	go get -u github.com/tcnksm/ghr

--- a/handler/go.mod
+++ b/handler/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-lambda-go v1.13.3
 	github.com/aws/aws-sdk-go v1.28.14
 	github.com/caarlos0/env v3.5.0+incompatible
-	github.com/google/go-cmp v0.4.0
+	github.com/google/go-cmp v0.5.6
 	github.com/nsf/jsondiff v0.0.0-20190712045011-8443391ee9b6
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect

--- a/handler/go.sum
+++ b/handler/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/nsf/jsondiff v0.0.0-20190712045011-8443391ee9b6 h1:qsqscDgSJy+HqgMTR+3NwjYJBbp1+honwDsszLoS+pA=

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This PR enables test_lambda to succeed in circleci. It pins versions of golangci-lint and gosec, and has merged UpdateVer branch changes into it.

Note: pinning to the latest version fo golangci-lint surfaces linting errors. To minimize time and testing required to get circleci working again right now, the last known passing version of golangci-lint is pinned.